### PR TITLE
Fix for Chrome transform behavior

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -48,9 +48,9 @@ div {
   -ms-backface-visibility: hidden;
   -o-backface-visibility: hidden;
   backface-visibility: hidden;
+
+  -webkit-transition: opacity 0.5s ease-in-out;
 }
-
-
 
 .card .back {
   background: blue;
@@ -59,7 +59,16 @@ div {
   -ms-transform: rotateY( 180deg );
   -o-transform: rotateY( 180deg );
   transform: rotateY( 180deg );
+  opacity:0;
 }
+
+.card.flipped img{
+  opacity:0;
+}
+.card.flipped .back{
+  opacity:1;
+}
+
 
 .message {
   width: 660px;


### PR DESCRIPTION
When flipping cards in Chrome, the diagonal lines temporarily appear on the front-face of the card. I added a webkit-transition on opacity to make the card flip feel right in Chrome.
