### PR TITLE
Card back isssue fix

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -37,6 +37,10 @@ div {
   -o-transform: rotateY( 180deg );
   transform: rotateY( 180deg );
 }
+ 
+.card.flipped .back {
+  z-index: 100;
+}
 
 .card img {
   display: block;

--- a/app/index.html
+++ b/app/index.html
@@ -21,8 +21,8 @@
         -->
         <div class="container">
           <div class="card" ng-class="{flipped: tile.flipped}">
-              <img class="front" ng-src="img/back.png">
               <img class="back" ng-src="img/{{tile.title}}.png">
+              <img class="front" ng-src="img/back.png">
           </div>
         </div>
 

--- a/app/js/game.js
+++ b/app/js/game.js
@@ -27,11 +27,11 @@ function Game(tileNames) {
     tile.flip();
 
     if (!this.firstPick || this.secondPick) {
-
-      if (this.secondPick) {
+      if(this.secondPick) {
         this.firstPick.flip();
         this.secondPick.flip();
-        this.firstPick = this.secondPick = undefined;
+        this.firstPick = undefined;
+        this.secondPick = undefined;
       }
 
       this.firstPick = tile;


### PR DESCRIPTION
I don't know if this was an issue only I was experiencing(Chrome 20(stable), Linux), but backside-visibility did not have the intended effect and also due to the ordering of the .front and .back divs, the reverse of the back (or really front) of the card was visible and the "back" image was not.  Needless to say, made for quite the easy game!

I made a simple change to app.css giving the .back div on .flipped card have a higher z-index than the "front".  This does have one side effect however.  The front of the card is shown, and then flipped.  But still quite a better experience than before.  Have mercy, I only spent five minutes looking at this.

I also was attempting to change when the two cards were flipped back over when there was a wrong guess, but it appears that the change in state for Card.isFlipped did not propogate before the cards were being flipped again.  So I left it alone for now.  Maybe a $timeout would be appropriate?  I don't think leaving the two previously selected cards up until a new card(that's not flipped) is very nice from a UI perspective.
